### PR TITLE
`ビジュアルC++` → ` Visual C++`

### DIFF
--- a/docs/build/working-with-project-properties.md
+++ b/docs/build/working-with-project-properties.md
@@ -47,7 +47,7 @@ IDE では、プロジェクトをビルドするために必要なすべての�
 
 - [C++ デバッグ構成のプロジェクト設定](/visualstudio/debugger/project-settings-for-a-cpp-debug-configuration)
 - [デバッガーの設定と準備](/visualstudio/debugger/debugger-settings-and-preparation)
-- [デバッグの準備:ビジュアルC++プロジェクトの種類](/visualstudio/debugger/debugging-preparation-visual-cpp-project-types)
+- [デバッグの準備: Visual C++プロジェクトの種類](/visualstudio/debugger/debugging-preparation-visual-cpp-project-types)
 - [Visual Studio デバッガーでのシンボル (.pdb) ファイルとソース ファイルの指定](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger)
 
 ## <a name="c-compiler-and-linker-options"></a>C++コンパイラオプションとリンカーオプション


### PR DESCRIPTION
ここは製品名なのでカタカナにしてはダメだと思います。

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
